### PR TITLE
Fixed call_user_func_array() expects parameter 1 to be a valid callback, class 'ApnsPHP_Message' does not have a method 'badge'

### DIFF
--- a/Apns.php
+++ b/Apns.php
@@ -133,7 +133,7 @@ class Apns extends AbstractApnsGcm
         $message = new \ApnsPHP_Message($token);
         $message->setText($text);
         foreach ($args as $method => $value) {
-            if (strpos($message, 'set') === false) {
+            if (strpos($method, 'set') === false) {
                 $method = 'set' . ucfirst($method);
             }
             $value = is_array($value) ? $value : [$value];


### PR DESCRIPTION
"exception 'yii\base\ErrorException' with message
'call_user_func_array() expects parameter 1 to be a valid callback,
class 'ApnsPHP_Message' does not have a method 'badge'' in
.../bryglen/yii2-apns-gcm/Apns.php:140"