### PR TITLE
dynamicly set petFile before make push

### DIFF
--- a/Apns.php
+++ b/Apns.php
@@ -47,6 +47,42 @@ class Apns extends AbstractApnsGcm
 
     public function init()
     {
+        
+    }
+
+    public function setEnvironment($environment)
+    {
+        if ($environment) {
+            $this->environment = $environment;
+            return;
+        }
+        return -1;
+    }
+
+    public function setPemFile($pemFile)
+    {
+        if ($pemFile) {
+            $this->pemFile = $pemFile;
+            return;
+        }
+        return -1;
+    }
+
+    public function setOptions($options)
+    {
+        if ($options && is_array($options)) {
+            $this->options = $options;
+            return;
+        }
+        return -1;
+    }
+
+    public function __init($pemFile = null, $options = null, $environment = null)
+    {
+        $this->setEnvironment($environment);
+        $this->setPemFile($pemFile);
+        $this->setOptions($options);
+
         if (!in_array($this->environment, [self::ENVIRONMENT_SANDBOX, self::ENVIRONMENT_PRODUCTION])) {
             throw new InvalidConfigException('Environment is invalid.');
         }
@@ -61,7 +97,7 @@ class Apns extends AbstractApnsGcm
                     $this->getClient()->disconnect();
                 }
             }
-        );
+        );   
     }
 
     public function closeConnection()


### PR DESCRIPTION
added 3 set functions, which init params in Apns. I made it for dynamicly set petFile before make push(if you have many push certificates).
function init was cleared, becouse we not set params in config
Now appear one dependence - before send push we must do like
```
$apnsGcm = Yii::$app->apnsGcm;
$temp = $apnsGcm->getApnsClient();
$temp->pemFile = 'some_certificate.pem';
$temp->options = ['providerCertificatePassphrase' => 'some_pass_phrase'];
$temp->__init();
```
and you can set $pemFile/$options/$environment with __init function or with 3 finction setEnvironment/setPemFile/setOptions